### PR TITLE
Custom dataset for SHL Creation

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4195,9 +4195,15 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/react": {
+<<<<<<< HEAD
       "version": "18.0.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz",
       "integrity": "sha512-38ETy4tL+rn4uQQi7mB81G7V1g0u2ryquNmsVIOKUAEIDK+3CUjZ6rSRpdvS99dNBnkLFL83qfmtLacGOTIhwQ==",
+=======
+      "version": "17.0.48",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.48.tgz",
+      "integrity": "sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==",
+>>>>>>> 1df8bed (create new route for custom ds, add checkbox handling)
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -20137,9 +20143,15 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/react": {
+<<<<<<< HEAD
       "version": "18.0.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz",
       "integrity": "sha512-38ETy4tL+rn4uQQi7mB81G7V1g0u2ryquNmsVIOKUAEIDK+3CUjZ6rSRpdvS99dNBnkLFL83qfmtLacGOTIhwQ==",
+=======
+      "version": "17.0.48",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.48.tgz",
+      "integrity": "sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==",
+>>>>>>> 1df8bed (create new route for custom ds, add checkbox handling)
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -385,13 +385,11 @@ const defaultImmunizations: Promise<StoredSHC[]> = Promise.all(
 
 export function SHLinkCreate() {
   let navigate = useNavigate();
-  let location = useLocation();
   let { store, dispatch } = useStore();
   let [usePasscode, setUsePasscode] = useState(false);
   let [passcode, setPasscode] = useState('1234');
+  let [datasetName, setDataSetName] = useState(`Custom Dataset ${Object.keys(store.sharing).length}`);
   let [expires, setExpires] = useState(false);
-
-  const { custom } = location.state as LocationState || {}; 
 
   const handleOnChange = (index: Number) => {
     const updatedCheck = isChecked.map((item: boolean, i: Number) => {
@@ -403,6 +401,7 @@ export function SHLinkCreate() {
   let oneMonthExpiration = new Date(new Date().getTime() + 1000 * 3600 * 24 * 31);
   let [expiresDate, setExpiresDate] = useState(oneMonthExpiration.toISOString().slice(0, 10));
   let [searchParams] = useSearchParams();
+  let custom = Boolean(searchParams.get('custom') === 'true');
   let datasetId = Number(searchParams.get('ds'));
   let ds = store.sharing[datasetId];
   let vaccines = (custom ? Object.values(store.vaccines) : Object.values(store.vaccines).filter(filterForTypes(ds.shcTypes)).filter(filterForIds(ds.shcs)));
@@ -414,11 +413,10 @@ export function SHLinkCreate() {
     if (custom) {
       const checkedVaccinations = vaccines.map(card => card.id).filter((card, i) => isChecked[i] === true);
       // create new DataSet using the checked vaccinations
-      // TODO: Allow user to rename the dataset
       datasetId = Object.keys(store.sharing).length;
       const customDataSet : DataSet = {
         id: datasetId,
-        name: `Custom DataSet ${datasetId}`,
+        name: datasetName,
         shcs: checkedVaccinations,
         shlinks: {}
       };
@@ -468,7 +466,7 @@ export function SHLinkCreate() {
                {fe[1].resource.occurrenceDateTime} {fe[0].resource.name[0].given} {fe[0].resource.name[0].family}{' '}
                {drug.slice(0, 23)}
                {drug.length > 20 ? '...' : ''} at {location}
-                </label>q
+                </label>
             </li>
             )
           } else {
@@ -482,6 +480,10 @@ export function SHLinkCreate() {
           }
         })}
       </ol>
+      {custom && 
+      <>
+        Custom Dataset Name: <input type='text' value={datasetName} onChange={(e) => setDataSetName(e.target.value)} /> <br></br>
+      </>}
       <button onClick={activate}>Activate new sharing link</button>
     </>
   );
@@ -600,14 +602,10 @@ export function SHLinks() {
       ))}
       <h4>
         New Custom Data Set
-        <button onClick={() => navigate('/health-links/new?custom=true', {state: {custom: true}})}>Create new dataset and link</button>
+        <button onClick={() => navigate('/health-links/new?custom=true')}>Create new dataset and link</button>
       </h4>
     </div>
   );
-}
-
-interface LocationState {
-  custom?: boolean
 }
 
 interface AppState {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -391,10 +391,11 @@ export function SHLinkCreateCustom() {
   let [usePin, setUsePin]= useState(false);
   let [pin, setPin] = useState('1234');
   let [expires, setExpires] = useState(false);
-  // list of checked vaccinations to include in the created SHLink
+  // list of checked vaccination ids to include in the created SHLink
   const [checkedVaccinations, setCheckedVaccinations] = useState<number[]>([]);
-  // state for keeping track of checked/unchecked vaccines
+  
   const defaultArray = new Array(allVaccineCards.length).fill(false)
+  // state for keeping track of checked/unchecked vaccines
   const [isChecked, setIsChecked] = useState<Array<boolean>>(defaultArray);
 
   let oneMonthExpiration = new Date(new Date().getTime() + 1000 * 3600 * 24 * 31);
@@ -405,7 +406,8 @@ export function SHLinkCreateCustom() {
       return i === index ? !item : item
     });
 
-    // update checked vaccinations to feed into new DataSet
+    // update checked vaccinations that will be used to create
+    // the new custom DataSet
     const updatedCheckedVaccinations: number[] = [];
     updatedCheck.forEach((item, i) => {
       if (item === true) {
@@ -417,7 +419,7 @@ export function SHLinkCreateCustom() {
   }
 
   async function activate() {
-    // create new dataset using the checked vaccinations
+    // create new DataSet using the checked vaccinations
     const dsId = idGenerator();
     const customDataSet : DataSet = {
       id: dsId,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -391,12 +391,10 @@ export function SHLinkCreateCustom() {
   let [usePin, setUsePin]= useState(false);
   let [pin, setPin] = useState('1234');
   let [expires, setExpires] = useState(false);
-  // list of checked vaccination ids to include in the created SHLink
-  const [checkedVaccinations, setCheckedVaccinations] = useState<number[]>([]);
-  
+ 
   const defaultArray = new Array(allVaccineCards.length).fill(false)
   // state for keeping track of checked/unchecked vaccines
-  const [isChecked, setIsChecked] = useState<Array<boolean>>(defaultArray);
+  const [isChecked, setIsChecked] = useState<boolean[]>(defaultArray);
 
   let oneMonthExpiration = new Date(new Date().getTime() + 1000 * 3600 * 24 * 31);
   let [expiresDate, setExpiresDate] = useState(oneMonthExpiration.toISOString().slice(0, 10));
@@ -405,20 +403,11 @@ export function SHLinkCreateCustom() {
     const updatedCheck = isChecked.map((item: boolean, i: Number) => {
       return i === index ? !item : item
     });
-
-    // update checked vaccinations that will be used to create
-    // the new custom DataSet
-    const updatedCheckedVaccinations: number[] = [];
-    updatedCheck.forEach((item, i) => {
-      if (item === true) {
-        updatedCheckedVaccinations.push(allVaccineCards[i].id);
-      }
-    });
     setIsChecked(updatedCheck);
-    setCheckedVaccinations(updatedCheckedVaccinations); 
   }
 
   async function activate() {
+    const checkedVaccinations = allVaccineCards.map(card => card.id).filter((card, i) => isChecked[i] === true);
     // create new DataSet using the checked vaccinations
     const dsId = idGenerator();
     const customDataSet : DataSet = {

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
 import { HashRouter, Route, Routes } from "react-router-dom";
-import App, { SettingsPage, SHLinkCreate, SHLinkCreateCustom, SHLinkDetail, SHLinks, Vaccines } from './App';
+import App, { SettingsPage, SHLinkCreate, SHLinkDetail, SHLinks, Vaccines } from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
 
@@ -13,7 +13,6 @@ root.render(
         <Route path="/" element={<App />}>
           <Route index element={<Vaccines/>} />
           <Route path="health-links/new" element={<SHLinkCreate />} />
-          <Route path="health-links/new-custom" element={<SHLinkCreateCustom />} />
           <Route path="health-links" element={<SHLinks />} />
           <Route path="health-links/:datasetId/:shlinkId" element={<SHLinkDetail />} />
           <Route path="settings" element={<SettingsPage />} />

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
 import { HashRouter, Route, Routes } from "react-router-dom";
-import App, { SettingsPage, SHLinkCreate, SHLinkDetail, SHLinks, Vaccines } from './App';
+import App, { SettingsPage, SHLinkCreate, SHLinkCreateCustom, SHLinkDetail, SHLinks, Vaccines } from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
 
@@ -13,6 +13,7 @@ root.render(
         <Route path="/" element={<App />}>
           <Route index element={<Vaccines/>} />
           <Route path="health-links/new" element={<SHLinkCreate />} />
+          <Route path="health-links/new-custom" element={<SHLinkCreateCustom />} />
           <Route path="health-links" element={<SHLinks />} />
           <Route path="health-links/:datasetId/:shlinkId" element={<SHLinkDetail />} />
           <Route path="settings" element={<SettingsPage />} />


### PR DESCRIPTION
# Summary
Adds the ability for the user to create a SMART Health Link for a custom vaccine data set.

## New Behavior
The user can now create a new custom data set from all the available vaccines, and create a new sharing link for it. If the link is deleted, another one can be created since the data set will be saved to local storage.

## Code Changes
* New route “health-links/new-custom” for creating a custom dataset and then creating a SHLink for it
* Updates the reducer to add a new dataset 
* New helper function `filterForIds` to filter all the vaccines to those that should be included in a data set
* New component `SHCLinkCreateCustom` that displays all the vaccines, keeps track of check boxes for the vaccines, and allows for a new data set to be created along with a new SHLink for that dataset

# Testing Guidance
* Follow the [server setup instructions](https://github.com/dvci/vaxx.link/tree/main/server) from the vaxx.link/server directory. The server will run on port 8000.
* Run the UI with `npm start` from the vaxx.link/ui directory. The app will run on port 3000 and is accessible at http://localhost:3000/.
* Navigate to “Health Links” in the nav bar. There should be two default datasets already populated - All Vaccines and School Vaccines. There should be a third header that says “New Custom Data Set.” Click on the “Create new link” next to the “New Custom Data Set” header. 
* After clicking on the button, you should be navigated to a new page for selecting the vaccines to include in the new data set. Select some of the vaccines, then click “Activate New Sharing Link.”
* After clicking on the button, you will be brought back to the Health Links page. Check that a the custom data set has been created (its header defaults to Custom Data Set {data set id}.) A SHLink should be created for the data set. To check that the data set was appropriately filtered to just include the checked vaccines, try deactivating the SHLink and clicking on “Create new link” again. The options should be limited to those that were checked when creating the custom data set.